### PR TITLE
bumped version of dockerfile

### DIFF
--- a/data/docker-compose.yml
+++ b/data/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.4"
 x-redash-service: &redash-service
   image: redash/redash:8.0.0.b32245
   depends_on:


### PR DESCRIPTION
version 3.4 is required for extension fields ("x-redash-service");
see https://docs.docker.com/compose/compose-file/#extension-fields
for version two and up and including version 3.3 you'd get a confusing
error message from docker-compose:

"""ERROR: The Compose file './docker-compose.yml' is invalid because:
Invalid top-level property "x-redash-service". Valid top-level sections
for this Compose file are: secrets, version, volumes, services, configs,
networks, and extensions starting with "x-".

You might be seeing this error because you're using the wrong Compose
file version.[...]
"""