### PR TITLE
update setup.sh (tested with Ubuntu 20.04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Setup script for Redash with Docker on Ubuntu 18.04.
+# Setup script for Redash with Docker on Ubuntu 20.04.
 
-This is a reference setup for Redash on a single Ubuntu 18.04 server, which uses Docker and Docker Compose for deployment and management.
+This is a reference setup for Redash on a single Ubuntu 20.04 server, which uses Docker and Docker Compose for deployment and management.
 
 This is the same setup we use for our official images (for AWS & Google Cloud) and can be used as reference if you want to manually setup Redash in a different environment (different OS or different deployment location).
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a reference setup for Redash on a single Ubuntu 20.04 server, which uses
 
 This is the same setup we use for our official images (for AWS & Google Cloud) and can be used as reference if you want to manually setup Redash in a different environment (different OS or different deployment location).
 
-* `setup.sh` is the script that installs everything and creates the directories.
-* `docker-compose.yml` is the Docker Compose setup we use.
-* `packer.json` is Packer configuration we use to create the Cloud images.
+- `setup.sh` is the script that installs everything and creates the directories.
+- `docker-compose.yml` is the Docker Compose setup we use.
+- `packer.json` is Packer configuration we use to create the Cloud images.
 
 ## FAQ
 

--- a/setup.sh
+++ b/setup.sh
@@ -63,16 +63,16 @@ setup_compose() {
   REQUESTED_CHANNEL=stable
   LATEST_VERSION=$(curl -s "https://version.redash.io/api/releases?channel=$REQUESTED_CHANNEL" | json_pp | grep "docker_image" | head -n 1 | awk 'BEGIN{FS=":"}{print $3}' | awk 'BEGIN{FS="\""}{print $1}')
 
-  cd "$REDASH_BASE_PATH"
-  GIT_BRANCH="${REDASH_BRANCH:-master}" # Default branch/version to master if not specified in REDASH_BRANCH env var
-  curl -OL https://raw.githubusercontent.com/getredash/setup/"$GIT_BRANCH"/data/docker-compose.yml
-  sed -ri "s/image: redash\/redash:([A-Za-z0-9.-]*)/image: redash\/redash:$LATEST_VERSION/" docker-compose.yml
-  echo "export COMPOSE_PROJECT_NAME=redash" >>~/.profile
-  echo "export COMPOSE_FILE=$REDASH_BASE_PATH/docker-compose.yml" >>~/.profile
-  export COMPOSE_PROJECT_NAME=redash
-  export COMPOSE_FILE=$REDASH_BASE_PATH/docker-compose.yml
-  sudo docker-compose run --rm server create_db
-  sudo docker-compose up -d
+    cd $REDASH_BASE_PATH
+    GIT_BRANCH="${REDASH_BRANCH:-master}" # Default branch/version to master if not specified in REDASH_BRANCH env var
+    curl -OL https://raw.githubusercontent.com/getredash/setup/${GIT_BRANCH}/data/docker-compose.yml
+    sed -ri "s/image: redash\/redash:([A-Za-z0-9.-]*)/image: redash\/redash:$LATEST_VERSION/" docker-compose.yml
+    echo "export COMPOSE_PROJECT_NAME=redash" >> ~/.profile
+    echo "export COMPOSE_FILE=$REDASH_BASE_PATH/docker-compose.yml" >> ~/.profile
+    export COMPOSE_PROJECT_NAME=redash
+    export COMPOSE_FILE=$REDASH_BASE_PATH/docker-compose.yml
+    sudo docker-compose run --rm server create_db
+    sudo docker-compose up -d
 }
 
 install_docker

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ install_docker(){
     "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
     "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
     sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
     # Install Docker Compose
     sudo ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose

--- a/setup.sh
+++ b/setup.sh
@@ -9,14 +9,18 @@ install_docker(){
     export DEBIAN_FRONTEND=noninteractive
     sudo apt-get -qqy update
     DEBIAN_FRONTEND=noninteractive sudo -E apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
-    sudo apt-get -yy install apt-transport-https ca-certificates curl software-properties-common pwgen
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    sudo apt-get update && sudo apt-get -y install docker-ce
+    sudo apt-get -yy install apt-transport-https ca-certificates curl software-properties-common pwgen gnupg
+    sudo install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg
+    echo \
+    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-  # Install Docker Compose
-  sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-"$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-  sudo chmod +x /usr/local/bin/docker-compose
+    # Install Docker Compose
+    sudo ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
 
   # Allow current user to run Docker commands
   sudo usermod -aG docker "$USER"

--- a/setup.sh
+++ b/setup.sh
@@ -4,44 +4,44 @@ set -eu
 
 REDASH_BASE_PATH=/opt/redash
 
-install_docker(){
-    # Install Docker
-    export DEBIAN_FRONTEND=noninteractive
-    sudo apt-get -qqy update
-    DEBIAN_FRONTEND=noninteractive sudo -E apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
-    sudo apt-get -yy install apt-transport-https ca-certificates curl software-properties-common pwgen gnupg
-    sudo install -m 0755 -d /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    sudo chmod a+r /etc/apt/keyrings/docker.gpg
-    echo \
-    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-    "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+install_docker() {
+  # Install Docker
+  export DEBIAN_FRONTEND=noninteractive
+  sudo apt-get -qqy update
+  DEBIAN_FRONTEND=noninteractive sudo -E apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+  sudo apt-get -yy install apt-transport-https ca-certificates curl software-properties-common pwgen gnupg
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  echo \
+    "deb [arch=""$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    ""$(. /etc/os-release && echo "$VERSION_CODENAME") stable" |
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-    # Install Docker Compose
-    sudo ln -sfv /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
+  # Install Docker Compose
+  sudo ln -sfv /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
 
   # Allow current user to run Docker commands
   sudo usermod -aG docker "$USER"
 }
 
 create_directories() {
-    if [ ! -e $REDASH_BASE_PATH ]; then
-        sudo mkdir -p $REDASH_BASE_PATH
-        sudo chown "$USER:" $REDASH_BASE_PATH
-    fi
+  if [ ! -e "$REDASH_BASE_PATH" ]; then
+    sudo mkdir -p "$REDASH_BASE_PATH"
+    sudo chown "$USER:" "$REDASH_BASE_PATH"
+  fi
 
-    if [ ! -e $REDASH_BASE_PATH/postgres-data ]; then
-        mkdir $REDASH_BASE_PATH/postgres-data
-    fi
+  if [ ! -e "$REDASH_BASE_PATH"/postgres-data ]; then
+    mkdir "$REDASH_BASE_PATH"/postgres-data
+  fi
 }
 
 create_config() {
-    if [ -e $REDASH_BASE_PATH/env ]; then
-        rm $REDASH_BASE_PATH/env
-        touch $REDASH_BASE_PATH/env
-    fi
+  if [ -e "$REDASH_BASE_PATH"/env ]; then
+    rm "$REDASH_BASE_PATH"/env
+    touch "$REDASH_BASE_PATH"/env
+  fi
 
   COOKIE_SECRET=$(pwgen -1s 32)
   SECRET_KEY=$(pwgen -1s 32)
@@ -63,16 +63,16 @@ setup_compose() {
   REQUESTED_CHANNEL=stable
   LATEST_VERSION=$(curl -s "https://version.redash.io/api/releases?channel=$REQUESTED_CHANNEL" | json_pp | grep "docker_image" | head -n 1 | awk 'BEGIN{FS=":"}{print $3}' | awk 'BEGIN{FS="\""}{print $1}')
 
-    cd $REDASH_BASE_PATH
-    GIT_BRANCH="${REDASH_BRANCH:-master}" # Default branch/version to master if not specified in REDASH_BRANCH env var
-    curl -OL https://raw.githubusercontent.com/getredash/setup/${GIT_BRANCH}/data/docker-compose.yml
-    sed -ri "s/image: redash\/redash:([A-Za-z0-9.-]*)/image: redash\/redash:$LATEST_VERSION/" docker-compose.yml
-    echo "export COMPOSE_PROJECT_NAME=redash" >> ~/.profile
-    echo "export COMPOSE_FILE=$REDASH_BASE_PATH/docker-compose.yml" >> ~/.profile
-    export COMPOSE_PROJECT_NAME=redash
-    export COMPOSE_FILE=$REDASH_BASE_PATH/docker-compose.yml
-    sudo docker-compose run --rm server create_db
-    sudo docker-compose up -d
+  cd "$REDASH_BASE_PATH"
+  GIT_BRANCH="${REDASH_BRANCH:-master}" # Default branch/version to master if not specified in REDASH_BRANCH env var
+  curl -OL https://raw.githubusercontent.com/getredash/setup/"$GIT_BRANCH"/data/docker-compose.yml
+  sed -ri "s/image: redash\/redash:([A-Za-z0-9.-]*)/image: redash\/redash:$LATEST_VERSION/" docker-compose.yml
+  echo "export COMPOSE_PROJECT_NAME=redash" >>~/.profile
+  echo "export COMPOSE_FILE=$REDASH_BASE_PATH/docker-compose.yml" >>~/.profile
+  export COMPOSE_PROJECT_NAME=redash
+  export COMPOSE_FILE="$REDASH_BASE_PATH"/docker-compose.yml
+  sudo docker-compose run --rm server create_db
+  sudo docker-compose up -d
 }
 
 install_docker

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ install_docker(){
 create_directories() {
     if [ ! -e $REDASH_BASE_PATH ]; then
         sudo mkdir -p $REDASH_BASE_PATH
-        sudo chown $USER:$USER $REDASH_BASE_PATH
+        sudo chown "$USER:" $REDASH_BASE_PATH
     fi
 
     if [ ! -e $REDASH_BASE_PATH/postgres-data ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-# This script setups dockerized Redash on Ubuntu 18.04.
+# This script setups dockerized Redash on Ubuntu 20.04.
 set -eu
 
 REDASH_BASE_PATH=/opt/redash
 
-install_docker() {
-  # Install Docker
-  export DEBIAN_FRONTEND=noninteractive
-  sudo apt-get -qqy update
-  DEBIAN_FRONTEND=noninteractive sudo -E apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
-  sudo apt-get -yy install apt-transport-https ca-certificates curl software-properties-common pwgen
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  sudo apt-get update && sudo apt-get -y install docker-ce
+install_docker(){
+    # Install Docker
+    export DEBIAN_FRONTEND=noninteractive
+    sudo apt-get -qqy update
+    DEBIAN_FRONTEND=noninteractive sudo -E apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+    sudo apt-get -yy install apt-transport-https ca-certificates curl software-properties-common pwgen
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    sudo apt-get update && sudo apt-get -y install docker-ce
 
   # Install Docker Compose
   sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-"$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/setup.sh
+++ b/setup.sh
@@ -20,28 +20,28 @@ install_docker(){
     sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
     # Install Docker Compose
-    sudo ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
+    sudo ln -sfv /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
 
   # Allow current user to run Docker commands
   sudo usermod -aG docker "$USER"
 }
 
 create_directories() {
-  if [[ ! -e $REDASH_BASE_PATH ]]; then
-    sudo mkdir -p "$REDASH_BASE_PATH"
-    sudo chown "$USER": "$REDASH_BASE_PATH"
-  fi
+    if [ ! -e $REDASH_BASE_PATH ]; then
+        sudo mkdir -p $REDASH_BASE_PATH
+        sudo chown $USER:$USER $REDASH_BASE_PATH
+    fi
 
-  if [[ ! -e $REDASH_BASE_PATH/postgres-data ]]; then
-    mkdir "$REDASH_BASE_PATH"/postgres-data
-  fi
+    if [ ! -e $REDASH_BASE_PATH/postgres-data ]; then
+        mkdir $REDASH_BASE_PATH/postgres-data
+    fi
 }
 
 create_config() {
-  if [[ -e $REDASH_BASE_PATH/env ]]; then
-    rm "$REDASH_BASE_PATH"/env
-    touch "$REDASH_BASE_PATH"/env
-  fi
+    if [ -e $REDASH_BASE_PATH/env ]; then
+        rm $REDASH_BASE_PATH/env
+        touch $REDASH_BASE_PATH/env
+    fi
 
   COOKIE_SECRET=$(pwgen -1s 32)
   SECRET_KEY=$(pwgen -1s 32)


### PR DESCRIPTION
Update `setup.sh` Tested with Ubuntu 20.04.

* Ubuntu 18.04. [Reaching end of standard support on 31 May 2023](https://ubuntu.com/18-04) issue: #43
* Tested with Ubuntu 20.04.
* Change install Docker engine from [Install Docker Engine on Ubuntu \| Docker Documentation](https://docs.docker.com/engine/install/ubuntu/) 
  * 458751b25b484095dec20501820d7553a9386a28
* Change install for `docker-compose`
  * 458751b25b484095dec20501820d7553a9386a28
  * L20,L23
* bug fix 
  * f59265d8175681e3cf9acd1b8a73d236cb78084f
```
setup.sh: 30: [[: not found
setup.sh: 35: [[: not found
setup.sh: 41: [[: not found
```
* update README
  * 4c5f62b257db07c95d34d738fcf46e76d692408c
* change chown command from #41
  * 794030ecca101117fd620a00b31703c78979fdb2
* replace /opt/redash to $REDASH_BASE_PATH from #35 
  * 98b8c51f3505921a4a4b6494913c679145c7e3c1

