### PR TITLE
Disable this brain damaged restyle thing

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,2 @@
+---
+enabled: false


### PR DESCRIPTION
Having just spent *hours* getting some existing code to comply with shellharden, shfmt, and shellcheck... now the "restyled" check is apparently running some other (not clearly documented) version of the same things, which produces different output.

Lets nip this in the bud here, as having multiple people waste copious hours on this crap isn't acceptable.