### PR TITLE
Change Docker image for PostgreSQL 

### DIFF
--- a/data/docker-compose.yml
+++ b/data/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     image: redis:5.0-alpine
     restart: unless-stopped
   postgres:
-    image: postgres:9.6-alpine
+    image: pgautoupgrade/pgautoupgrade:15-alpine3.8
     env_file: /opt/redash/env
     volumes:
       - /opt/redash/postgres-data:/var/lib/postgresql/data

--- a/data/docker-compose.yml
+++ b/data/docker-compose.yml
@@ -34,13 +34,13 @@ services:
       WORKERS_COUNT: 2
   redis:
     image: redis:5.0-alpine
-    restart: always
+    restart: unless-stopped
   postgres:
     image: postgres:9.6-alpine
     env_file: /opt/redash/env
     volumes:
       - /opt/redash/postgres-data:/var/lib/postgresql/data
-    restart: always
+    restart: unless-stopped
   nginx:
     image: redash/nginx:latest
     ports:


### PR DESCRIPTION
# Change Docker image for PostgreSQL 

- PostgreSQL 9.6-alpine to pgautoupgrade:15-alpine3.8 0243ce47d60c3e7c76c0255d736e3fe50fd36e7f
  -  #24 Postgres 9.6 is EOL

ref: https://www.postgresql.org/support/versioning/

| Version | Current minor | Supported | First Release | Final Release |
|---------|---------------|-----------|---------------|---------------|
| 9.6     | 9.6.24        | No        | September 29, 2016 | November 11, 2021 |

# Restart policy for Docker containers has been changed

- Restart policy for Docker containers has been changed from `always` to `unless-stopped` in the following Docker Compose file:
  - `docker-compose.yml` 2e392dfab72b0f758ace5a26d54580e6d619ad0a
- ref: getredash/redash/pull/2325

## It works on the following environments:
- Redash 8.0.0.b32245
- pgautoupgrade:15-alpine3.8
- redis:5.0-alpine
- Docker 25.0.2
- Docker Compose v2.24.5
- Ubuntu 22.04.3 LTS

![image](https://github.com/getredash/setup/assets/1247622/e9708d50-6903-4212-bc3c-57cd356e4cce)
