### PR TITLE
Changed Redis image from 5.0-alpine to 7-alpine

### DIFF
--- a/data/docker-compose.yml
+++ b/data/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       WORKERS_COUNT: 2
   redis:
     image: redis:7-alpine
-    restart: always
+    restart: unless-stopped
   postgres:
     image: postgres:9.6-alpine
     env_file: /opt/redash/env

--- a/data/docker-compose.yml
+++ b/data/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       QUEUES: "queries"
       WORKERS_COUNT: 2
   redis:
-    image: redis:5.0-alpine
+    image: redis:7-alpine
     restart: always
   postgres:
     image: postgres:9.6-alpine


### PR DESCRIPTION
# Changed Redis image from 5.0-alpine to 7-alpine

- Redis 5.0-alpine to redis:7-alpine e363c056421d3ba23189fcd7cd62576ac1eff6b2
  - Redis 5.0 is EOL
  - ref: https://docs.redis.com/latest/rs/installing-upgrading/product-lifecycle/#endoflife-schedule
- The version selection was based on the following
https://github.com/getredash/redash/blob/af2f4af8a24165edc65d433ec25ef1462a563d17/compose.yaml#L52
```
 image: redis:7-alpine 
```


# Restart policy for Docker containers has been changed

- Restart policy for Docker containers has been changed from `always` to `unless-stopped` in the following Docker Compose files:
  - `docker-compose.yml` e8eb0ba97bc0b6def97dd66cf37654c1665eadc1
- ref: getredash/redash/pull/2325


## It works on the following environments:
- Redash 8.0.0.b32245
- pgautoupgrade:15-alpine3.8
- redis:7-alpine
- Docker 25.0.2
- Docker Compose v2.24.5
- Ubuntu 22.04.3 LTS
