### PR TITLE
Add support for Red Hat Enterprise Linux 8/9 and its clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ to manually setup Redash in a different environment (different OS or different d
 
 ## Tested
 
-- Debian 12.5 (Bookworm)
-- Ubuntu 20.04 LTS
-- Ubuntu 22.04 LTS
+- Alma Linux 8.x & 9.x
+- CentOS Stream 9.x
+- Debian 12.x
+- Oracle Linux 9.x
+- Red Hat Enterprise Linux 8.x & 9.x
+- Rocky Linux 8.x & 9.x
+- Ubuntu LTS 20.04 & 22.04
 
 ## FAQ
 
@@ -40,7 +44,7 @@ other Linux distributions.
 ### How do I remove Redash if I no longer need it?
 
 1. Stop the Redash container and remove the images using `docker compose down --volumes --rmi all`.
-2. Remove the following lines from `~/.profile` if they're present.
+2. Remove the following lines from `~/.profile` and `~/.bashrc` if they're present.
 
    ```
    export COMPOSE_PROJECT_NAME=redash

--- a/redash_make_default.sh
+++ b/redash_make_default.sh
@@ -2,7 +2,8 @@
 
 # Trivial script to add Redash to the user login profile
 
-cat <<EOF >>~/.profile
+cat <<EOF >>~/__TARGET_FILE__
+
 # Added by Redash 'redash_make_default.sh' script
 export COMPOSE_PROJECT_NAME=redash
 export COMPOSE_FILE=__BASE_PATH__/compose.yaml


### PR DESCRIPTION
This extends the Redash setup scripting to also work on Red Hat Enterprise Linux (RHEL) 8 and 9, and it's major clones:

* Alma Linux 8 & 9
* CentOS 8 & 9
* Oracle Linux 8 & 9
* Rocky Linux 8 & 9

As with the setup.sh script reworking from yesterday, this PR has an extra commit in it (branch name override) that will need manual removal prior to merging.

---

Note - I'll likely merge this tomorrow sometime after cleaning up the commit history and removing that branch override commit. :smile: