### PR TITLE
Add --overwrite option to setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,35 @@ to manually setup Redash in a different environment (different OS or different d
 - Rocky Linux 8.x & 9.x
 - Ubuntu LTS 20.04 & 22.04
 
+## How to use this
+
+This script should be run as the `root` user on a supported Linux system (as per above list):
+
+```
+# ./setup.sh
+```
+
+When run, the script will install the needed packages (mostly Docker) then install Redash, ready for you to configure
+and begin using.
+
+> [!IMPORTANT]
+> The very first time you load your Redash web interface it can take a while to appear, as the background Python code
+> is being compiled.  On subsequent visits, the pages should load much quicker (near instantly).
+
+## Optional parameters
+
+The setup script has (for now) a single optional parameter, `--overwrite`, used like this:
+
+```
+# ./setup.sh --overwrite
+```
+
+When this option is used, the setup script will delete the existing Redash environment file (`/opt/redash/env`) and
+Redash database, then set up a brand new (empty) Redash installation.
+
+> [!CAUTION]
+> ***DO NOT*** use this parameter if you want to keep your existing Redash installation!  It ***WILL*** be overwritten.
+
 ## FAQ
 
 ### Can I use this in production?

--- a/setup.sh
+++ b/setup.sh
@@ -205,7 +205,7 @@ setup_compose() {
   export COMPOSE_PROJECT_NAME=redash
   export COMPOSE_FILE="$REDASH_BASE_PATH"/compose.yaml
 
-  echo "** Initialising fresh Redash database **"
+  echo "** Initialising Redash database **"
   docker compose run --rm server create_db
 
   echo

--- a/setup.sh
+++ b/setup.sh
@@ -113,6 +113,9 @@ create_directories() {
 
     if [ "x$OVERWRITE" = "xyes" ]; then
       # We've been asked to overwrite the existing database, so delete the old one
+      echo "Shutting down any running Redash instance"
+      docker compose -f "$REDASH_BASE_PATH"/compose.yaml down
+
       echo "Removing old Redash PG database directory"
       rm -rf "$REDASH_BASE_PATH"/postgres-data
       mkdir "$REDASH_BASE_PATH"/postgres-data

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@
 set -eu
 
 REDASH_BASE_PATH=/opt/redash
+OVERWRITE=no
 
 # Ensure the script is being run as root
 ID=$(id -u)
@@ -16,6 +17,13 @@ fi
 if [ ! -f /etc/os-release ]; then
   echo "Unknown Linux distribution.  This script presently works only on Debian, Ubuntu, and RHEL (and compatible)"
   exit
+fi
+
+# Check if the --overwrite option was set
+if [ $# -ne 0 ]; then
+  if [ "x$1" = "x--overwrite" ]; then
+    OVERWRITE=yes
+  fi
 fi
 
 install_docker_debian() {
@@ -100,7 +108,16 @@ create_directories() {
     chown "$USER:" "$REDASH_BASE_PATH"
   fi
 
-  if [ ! -e "$REDASH_BASE_PATH"/postgres-data ]; then
+  if [ -e "$REDASH_BASE_PATH"/postgres-data ]; then
+    # PostgreSQL database directory seems to exist already
+
+    if [ "x$OVERWRITE" = "xyes" ]; then
+      # We've been asked to overwrite the existing database, so delete the old one
+      echo "Removing old Redash PG database directory"
+      rm -rf "$REDASH_BASE_PATH"/postgres-data
+      mkdir "$REDASH_BASE_PATH"/postgres-data
+    fi
+  else
     mkdir "$REDASH_BASE_PATH"/postgres-data
   fi
 }
@@ -108,24 +125,67 @@ create_directories() {
 create_env() {
   echo "** Creating Redash environment file **"
 
-  if [ -e "$REDASH_BASE_PATH"/env ]; then
-    rm "$REDASH_BASE_PATH"/env
-    touch "$REDASH_BASE_PATH"/env
-  fi
-
+  # Minimum mandatory values (when not just developing)
   COOKIE_SECRET=$(pwgen -1s 32)
   SECRET_KEY=$(pwgen -1s 32)
-  POSTGRES_PASSWORD=$(pwgen -1s 32)
-  REDASH_DATABASE_URL="postgresql://postgres:${POSTGRES_PASSWORD}@postgres/postgres"
+  PG_PASSWORD=$(pwgen -1s 32)
+  DATABASE_URL="postgresql://postgres:${PG_PASSWORD}@postgres/postgres"
+
+  if [ -e "$REDASH_BASE_PATH"/env ]; then
+    # There's already an environment file
+
+    if [ "x$OVERWRITE" = "xno" ]; then
+      echo
+      echo "Environment file already exists, reusing that one + and adding any missing (mandatory) values"
+
+      # Add any missing mandatory values
+      REDASH_COOKIE_SECRET=
+      REDASH_COOKIE_SECRET=$(. "$REDASH_BASE_PATH"/env && echo "$REDASH_COOKIE_SECRET")
+      if [ -z "$REDASH_COOKIE_SECRET" ]; then
+        echo "REDASH_COOKIE_SECRET=$COOKIE_SECRET" >> "$REDASH_BASE_PATH"/env
+        echo "REDASH_COOKIE_SECRET added to env file"
+      fi
+
+      REDASH_SECRET_KEY=
+      REDASH_SECRET_KEY=$(. "$REDASH_BASE_PATH"/env && echo "$REDASH_SECRET_KEY")
+      if [ -z "$REDASH_SECRET_KEY" ]; then
+        echo "REDASH_SECRET_KEY=$SECRET_KEY" >> "$REDASH_BASE_PATH"/env
+        echo "REDASH_SECRET_KEY added to env file"
+      fi
+
+      POSTGRES_PASSWORD=
+      POSTGRES_PASSWORD=$(. "$REDASH_BASE_PATH"/env && echo "$POSTGRES_PASSWORD")
+      if [ -z "$POSTGRES_PASSWORD" ]; then
+        POSTGRES_PASSWORD=$PG_PASSWORD
+        echo "POSTGRES_PASSWORD=$POSTGRES_PASSWORD" >> "$REDASH_BASE_PATH"/env
+        echo "POSTGRES_PASSWORD added to env file"
+      fi
+
+      REDASH_DATABASE_URL=
+      REDASH_DATABASE_URL=$(. "$REDASH_BASE_PATH"/env && echo "$REDASH_DATABASE_URL")
+      if [ -z "$REDASH_DATABASE_URL" ]; then
+        echo "REDASH_DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres/postgres" >> "$REDASH_BASE_PATH"/env
+        echo "REDASH_DATABASE_URL added to env file"
+      fi
+
+      echo
+      return
+    fi
+
+    # Remove existing environment file
+    rm -f "$REDASH_BASE_PATH"/env
+  fi
+
+  echo "Generating brand new environment file"
 
   cat <<EOF >"$REDASH_BASE_PATH"/env
 PYTHONUNBUFFERED=0
 REDASH_LOG_LEVEL=INFO
 REDASH_REDIS_URL=redis://redis:6379/0
-POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 REDASH_COOKIE_SECRET=$COOKIE_SECRET
 REDASH_SECRET_KEY=$SECRET_KEY
-REDASH_DATABASE_URL=$REDASH_DATABASE_URL
+POSTGRES_PASSWORD=$PG_PASSWORD
+REDASH_DATABASE_URL=$DATABASE_URL
 EOF
 }
 


### PR DESCRIPTION
Up until now the setup.sh script automatically deletes any existing environment file in `/opt/redash/env`, which has caught out numerous people and is a source of issues.

From now onwards, an existing environment file will be kept, with only missing mandatory fields added to it to help ensure a working configuration.

This commit also introduces a new (optional) `--overwrite` parameter to setup.sh, which tells it to completely overwrite any existing environment file and its matching database.

```
# sh setup.sh     <-- standard installation procedure for Redash
```

```
# sh setup.sh --overwrite   <-- deletes and recreates the existing env file and database
```

***DO NOT*** use the new `--overwrite` option if you want to keep your existing database, as it ***WILL*** cause your database to be replaced with an empty new one.