### PR TITLE
Add --preview option for installing the Redash preview image

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,27 @@ and begin using.
 
 ## Optional parameters
 
-The setup script has (for now) a single optional parameter, `--overwrite`, used like this:
+The setup script has two optional parameters, `--preview` and `--overwrite`.
+
+These can be used independently of each other, or used together.
+
+### --preview
+
+When the `--preview` parameter is given, the setup script will install the latest `preview`
+[image from Docker Hub](https://hub.docker.com/r/redash/redash/tags) instead of using the last official release.
+
+```
+# ./setup.sh --preview
+```
+
+### --overwrite
+
+When the `--overwrite` option is given, the setup script will delete the existing Redash environment file
+(`/opt/redash/env`) and Redash database, then set up a brand new (empty) Redash installation.
 
 ```
 # ./setup.sh --overwrite
 ```
-
-When this option is used, the setup script will delete the existing Redash environment file (`/opt/redash/env`) and
-Redash database, then set up a brand new (empty) Redash installation.
 
 > [!CAUTION]
 > ***DO NOT*** use this parameter if you want to keep your existing Redash installation!  It ***WILL*** be overwritten.

--- a/data/compose.yaml
+++ b/data/compose.yaml
@@ -1,5 +1,5 @@
 x-redash-service: &redash-service
-  image: redash/redash:10.1.0.b50633
+  image: redash/redash:__TAG__
   depends_on:
     - postgres
     - redis
@@ -10,21 +10,27 @@ services:
     <<: *redash-service
     command: server
     ports:
-      - "5000:5000"
+      - "__PORT__:5000"
     environment:
       REDASH_WEB_WORKERS: 4
   scheduler:
     <<: *redash-service
     command: scheduler
+    depends_on:
+      - server
   scheduled_worker:
     <<: *redash-service
     command: worker
+    depends_on:
+      - server
     environment:
       QUEUES: "scheduled_queries,schemas"
       WORKERS_COUNT: 1
   adhoc_worker:
     <<: *redash-service
     command: worker
+    depends_on:
+      - server
     environment:
       QUEUES: "queries"
       WORKERS_COUNT: 2
@@ -50,5 +56,5 @@ services:
     <<: *redash-service
     command: worker
     environment:
-      QUEUES: "periodic emails default"
+      QUEUES: "periodic,emails,default"
       WORKERS_COUNT: 1

--- a/redash_make_default.sh
+++ b/redash_make_default.sh
@@ -6,6 +6,6 @@ cat <<EOF >>~/__TARGET_FILE__
 
 # Added by Redash 'redash_make_default.sh' script
 export COMPOSE_PROJECT_NAME=redash
-export COMPOSE_FILE=__BASE_PATH__/compose.yaml
+export COMPOSE_FILE=__COMPOSE_FILE__
 EOF
 echo "Redash has now been set as the default Docker Compose project"


### PR DESCRIPTION
This PR adds a `--preview` option to the setup script, and sets things up to run the Docker Hub `preview` image instead of the last official release.

Its purpose is to allow people to run the `preview` image in near-production environments, for where that's an appropriate option.

---

~Note - this PR has an extra commit to force the branch name to this PR, and will need to be manually removed before merging.~ Removed it. :wink:

