### PR TITLE
Add --dont-start option to setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ and begin using.
 
 ## Optional parameters
 
-The setup script has two optional parameters, `--preview` and `--overwrite`.
+The setup script has three optional parameters, `--dont-start`, `--preview` and `--overwrite`.
 
-These can be used independently of each other, or used together.
+These can be used independently of each other, or with each other in any combination.
 
 ### --preview
 
@@ -54,6 +54,9 @@ When the `--preview` parameter is given, the setup script will install the lates
 
 ### --overwrite
 
+> [!CAUTION]
+> ***DO NOT*** use this parameter if you want to keep your existing Redash installation!  It ***WILL*** be overwritten.
+
 When the `--overwrite` option is given, the setup script will delete the existing Redash environment file
 (`/opt/redash/env`) and Redash database, then set up a brand new (empty) Redash installation.
 
@@ -61,8 +64,15 @@ When the `--overwrite` option is given, the setup script will delete the existin
 # ./setup.sh --overwrite
 ```
 
-> [!CAUTION]
-> ***DO NOT*** use this parameter if you want to keep your existing Redash installation!  It ***WILL*** be overwritten.
+### --dont-start
+
+When this option is given, the setup script will install Redash without starting it afterwards.
+
+This is useful for people wanting to customise or modify their Redash installation before it starts for the first time.
+
+```
+# ./setup.sh --dont-start
+```
 
 ## FAQ
 

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 set -eu
 
 REDASH_BASE_PATH=/opt/redash
-AUTOSTART=yes
+DONT_START=no
 OVERWRITE=no
 PREVIEW=no
 PORT=5000
@@ -30,7 +30,7 @@ while true
 do
   case "$1" in
     -d|--dont-start)
-      AUTOSTART=no
+      DONT_START=yes
       shift
       ;;
     -o|--overwrite)
@@ -274,7 +274,7 @@ setup_make_default() {
 }
 
 startup() {
-  if [ "x$AUTOSTART" = "xyes" ]; then
+  if [ "x$DONT_START" != "xyes" ]; then
     echo
     echo "*********************"
     echo "** Starting Redash **"


### PR DESCRIPTION
This installs Redash without automatically starting it afterwards.

It's intended for people who want to configure or customise Redash after installation, before it starts for the first time.

Can be used in conjunction with this: [How to add the Admin user without using the web interface](https://github.com/getredash/redash/wiki/How-to-add-the-first-user-(Admin)-to-Redash-without-using-the-web-interface)