### PR TITLE
Always use port 5000 for the web interface

### DIFF
--- a/data/compose.yaml
+++ b/data/compose.yaml
@@ -10,7 +10,7 @@ services:
     <<: *redash-service
     command: server
     ports:
-      - "__PORT__:5000"
+      - "5000:5000"
     environment:
       REDASH_WEB_WORKERS: 4
   scheduler:

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,6 @@ REDASH_BASE_PATH=/opt/redash
 DONT_START=no
 OVERWRITE=no
 PREVIEW=no
-PORT=5000
 
 # Ensure the script is being run as root
 ID=$(id -u)
@@ -46,7 +45,6 @@ do
       ;;
     -p|--preview)
       PREVIEW=yes
-      PORT=5001
       shift
       ;;
     -h|--help)
@@ -265,8 +263,6 @@ setup_compose() {
     TAG="preview"
   fi
   sed -i "s|__TAG__|$TAG|" compose.yaml
-  # The preview image uses a different port to access the web interface
-  sed -i "s|__PORT__|$PORT|" compose.yaml
   export COMPOSE_FILE="$REDASH_BASE_PATH"/compose.yaml
   export COMPOSE_PROJECT_NAME=redash
 }
@@ -293,7 +289,7 @@ startup() {
     docker compose up -d
 
     echo
-    echo "Redash has been installed and is ready for configuring at http://$(hostname -f):$PORT"
+    echo "Redash has been installed and is ready for configuring at http://$(hostname -f):5000"
     echo
   else
     echo


### PR DESCRIPTION
This PR changes the Redash production setup to always use port 5000.

In theory this should help keep things simple for production setups. :smile:

This was after some discussion with @arikfr, who pointed out that using port 5001 was intended to only be for development environments due to macOS seeming to use port 5000 itself.