### PR TITLE
Datestamp previous Redash installation files

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -233,7 +233,8 @@ create_env() {
     fi
 
     # Move any existing environment file out of the way
-    mv -f "$REDASH_BASE_PATH"/env "$REDASH_BASE_PATH"/env.old
+    TIMESTAMP_NOW=$(date +'%Y.%m.%d-%H.%M')
+    mv -f "${REDASH_BASE_PATH}/env" "${REDASH_BASE_PATH}/env.old.${TIMESTAMP_NOW}"
   fi
 
   echo "Generating brand new environment file"

--- a/setup.sh
+++ b/setup.sh
@@ -167,14 +167,14 @@ create_directories() {
     # PostgreSQL database directory seems to exist already
 
     if [ "x$OVERWRITE" = "xyes" ]; then
-      # We've been asked to overwrite the existing database, so delete the old one
+      # We've been asked to overwrite the existing database
       echo "Shutting down any running Redash instance"
       if [ -e "$REDASH_BASE_PATH"/compose.yaml ]; then
         docker compose -f "$REDASH_BASE_PATH"/compose.yaml down
       fi
 
-      echo "Removing old Redash PG database directory"
-      rm -rf "$REDASH_BASE_PATH"/postgres-data
+      echo "Moving old Redash PG database directory out of the way"
+      mv "${REDASH_BASE_PATH}/postgres-data" "${REDASH_BASE_PATH}/postgres-data-${TIMESTAMP_NOW}"
       mkdir "$REDASH_BASE_PATH"/postgres-data
     fi
   else

--- a/setup.sh
+++ b/setup.sh
@@ -233,7 +233,6 @@ create_env() {
     fi
 
     # Move any existing environment file out of the way
-    TIMESTAMP_NOW=$(date +'%Y.%m.%d-%H.%M')
     mv -f "${REDASH_BASE_PATH}/env" "${REDASH_BASE_PATH}/env.old-${TIMESTAMP_NOW}"
   fi
 
@@ -258,7 +257,7 @@ setup_compose() {
   cd "$REDASH_BASE_PATH"
   GIT_BRANCH="${REDASH_BRANCH:-master}" # Default branch/version to master if not specified in REDASH_BRANCH env var
   if [ "x$OVERWRITE" = "xyes" -a -e compose.yaml ]; then
-    mv -f compose.yaml compose.yaml.old
+    mv -f compose.yaml compose.yaml.old-${TIMESTAMP_NOW}
   fi
   curl -fsSOL https://raw.githubusercontent.com/getredash/setup/"$GIT_BRANCH"/data/compose.yaml
   TAG="10.1.0.b50633"
@@ -308,6 +307,8 @@ startup() {
 echo
 echo "Redash installation script. :)"
 echo
+
+TIMESTAMP_NOW=$(date +'%Y.%m.%d-%H.%M')
 
 # Run the distro specific Docker installation
 PROFILE=.profile

--- a/setup.sh
+++ b/setup.sh
@@ -234,7 +234,7 @@ create_env() {
 
     # Move any existing environment file out of the way
     TIMESTAMP_NOW=$(date +'%Y.%m.%d-%H.%M')
-    mv -f "${REDASH_BASE_PATH}/env" "${REDASH_BASE_PATH}/env.old.${TIMESTAMP_NOW}"
+    mv -f "${REDASH_BASE_PATH}/env" "${REDASH_BASE_PATH}/env.old-${TIMESTAMP_NOW}"
   fi
 
   echo "Generating brand new environment file"
@@ -257,7 +257,7 @@ setup_compose() {
 
   cd "$REDASH_BASE_PATH"
   GIT_BRANCH="${REDASH_BRANCH:-master}" # Default branch/version to master if not specified in REDASH_BRANCH env var
-  if [ "x$OVERWRITE" = "xyes" ]; then
+  if [ "x$OVERWRITE" = "xyes" -a -e compose.yaml ]; then
     mv -f compose.yaml compose.yaml.old
   fi
   curl -fsSOL https://raw.githubusercontent.com/getredash/setup/"$GIT_BRANCH"/data/compose.yaml


### PR DESCRIPTION
When the setup.sh script is run with the `--overwrite` option, it moves any existing files (`env`, `compose.yaml`, `postgres-data`) out of the way before creating new ones.

Subsequent runs of the setup script will blindly overwrite the backup files.

Instead of doing that, if we add a timestamp to the backed up files then we avoid this potential overwriting problem.