### PR TITLE
Fix pwgen 'Command not found' error when Docker is pre-installed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -369,21 +369,21 @@ fi
 
 # Ensure pwgen is available (needed for generating secrets)
 if ! command -v pwgen >/dev/null 2>&1; then
-  echo "** Installing pwgen **"
-  if [ -f /etc/debian_version ]; then
-    apt-get update -qq
-    apt-get install -y pwgen
-  elif [ -f /etc/redhat-release ]; then
-    if command -v dnf >/dev/null 2>&1; then
-      dnf install -y pwgen
-    else
-      yum install -y pwgen
-    fi
-  else
-    echo "Warning: pwgen not found and unable to install automatically on this system."
-    echo "Please install pwgen manually: sudo apt-get install pwgen (Debian/Ubuntu) or sudo yum install pwgen (RHEL/CentOS)"
-    exit 1
-  fi
+	echo "** Installing pwgen **"
+	if [ -f /etc/debian_version ]; then
+		apt-get update -qq
+		apt-get install -y pwgen
+	elif [ -f /etc/redhat-release ]; then
+		if command -v dnf >/dev/null 2>&1; then
+			dnf install -y pwgen
+		else
+			yum install -y pwgen
+		fi
+	else
+		echo "Warning: pwgen not found and unable to install automatically on this system."
+		echo "Please install pwgen manually: sudo apt-get install pwgen (Debian/Ubuntu) or sudo yum install pwgen (RHEL/CentOS)"
+		exit 1
+	fi
 fi
 
 # Do the things that aren't distro specific

--- a/setup.sh
+++ b/setup.sh
@@ -367,6 +367,25 @@ else
   esac
 fi
 
+# Ensure pwgen is available (needed for generating secrets)
+if ! command -v pwgen >/dev/null 2>&1; then
+  echo "** Installing pwgen **"
+  if [ -f /etc/debian_version ]; then
+    apt-get update -qq
+    apt-get install -y pwgen
+  elif [ -f /etc/redhat-release ]; then
+    if command -v dnf >/dev/null 2>&1; then
+      dnf install -y pwgen
+    else
+      yum install -y pwgen
+    fi
+  else
+    echo "Warning: pwgen not found and unable to install automatically on this system."
+    echo "Please install pwgen manually: sudo apt-get install pwgen (Debian/Ubuntu) or sudo yum install pwgen (RHEL/CentOS)"
+    exit 1
+  fi
+fi
+
 # Do the things that aren't distro specific
 create_directories
 create_env


### PR DESCRIPTION
Fixes #85

## Problem
When Docker and Docker Compose are already installed on the system, the setup script skips the Docker installation functions. However, these functions also install the `pwgen` package, which is required for generating secrets. This results in a "Command not found" error when the script tries to use `pwgen`.

## Solution
Added a separate check for `pwgen` availability after the Docker installation section. If `pwgen` is not found, the script will automatically install it based on the detected Linux distribution.

## Changes
- Added `pwgen` availability check after Docker installation
- Supports automatic installation on Debian/Ubuntu (`apt-get`) and RHEL/CentOS (`dnf`/`yum`) systems
- Provides clear error message and manual installation instructions for unsupported systems
- Applied consistent shell formatting to the new code section

## Testing
This fix ensures that `pwgen` is available regardless of whether Docker was pre-installed or installed by the script, resolving the issue reported in #85.