### PR TITLE
Update Redash version example in README to v25.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ When the `--preview` parameter is given, the setup script will install the lates
 When the `--version` parameter is given, the setup script will install the specified version of Redash instead of the latest stable release.
 
 ```
-# ./setup.sh --version 25.1.0
+# ./setup.sh --version 25.8.0
 ```
 
 This option allows you to install a specific version of Redash, which can be useful for testing, compatibility checks, or ensuring reproducible environments.


### PR DESCRIPTION
## Overview
Update the Redash version example in README.md from v25.1.0 to the latest stable release v25.8.0.

## Changes
- Updated the `--version` parameter example from `25.1.0` to `25.8.0`
- Reflects the current latest stable Redash release (released August 1, 2025)

## Why This Change
- Keeps documentation current with the latest stable release
- Provides users with an up-to-date example when using the `--version` parameter
- Ensures consistency between documentation and available releases

This is a simple documentation update with no functional changes to the setup script.