### PR TITLE
Remove the software-properties-common package which is not present in trixie

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -76,7 +76,7 @@ install_docker_debian() {
 	export DEBIAN_FRONTEND=noninteractive
 	apt-get -qqy update
 	DEBIAN_FRONTEND=noninteractive apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
-	apt-get -yy install apt-transport-https ca-certificates curl software-properties-common pwgen gnupg
+	apt-get -yy install apt-transport-https ca-certificates curl pwgen gnupg
 
 	# Add Docker GPG signing key
 	if [ ! -f "/etc/apt/keyrings/docker.gpg" ]; then


### PR DESCRIPTION
Debian Trixie (current release) does not contain software-properties-common due to a security vulnerability: 

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038747

The setup script does not actually use this package, so it can be removed.