### PR TITLE
Remove software-properties-common from Ubuntu installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -142,7 +142,7 @@ install_docker_ubuntu() {
 	export DEBIAN_FRONTEND=noninteractive
 	apt-get -qqy update
 	DEBIAN_FRONTEND=noninteractive sudo -E apt-get -qqy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
-	apt-get -yy install apt-transport-https ca-certificates curl software-properties-common pwgen gnupg
+	apt-get -yy install apt-transport-https ca-certificates curl pwgen gnupg
 
 	# Add Docker GPG signing key
 	if [ ! -f "/etc/apt/keyrings/docker.gpg" ]; then


### PR DESCRIPTION
Fixes #94

Following up on PR #93 which removed `software-properties-common` from Debian installation, this PR removes the same unnecessary package from Ubuntu installation.

## Changes
- Remove `software-properties-common` from Ubuntu installation function
- Package is not actually used in the setup script
- Improves consistency with Debian installation

## Testing
- ✅ Ubuntu 22.04: Setup script runs successfully without `software-properties-common`
- ✅ Confirmed package is not used anywhere in the script

## Related
- Closes #94
- Related to PR #93 (Debian version)

This ensures both Debian and Ubuntu installations are consistent and don't include unnecessary packages.